### PR TITLE
🚨 [CW-24278] fix: add MGL prefix to avoid duplicate symbol errors

### DIFF
--- a/packages/react-native-quick-crypto/android/src/main/cpp/cpp-adapter.cpp
+++ b/packages/react-native-quick-crypto/android/src/main/cpp/cpp-adapter.cpp
@@ -30,8 +30,8 @@ class CryptoCppAdapter : public jni::HybridClass<CryptoCppAdapter> {
     auto object = jsi::Object::createFromHostObject(runtime, hostObject);
     runtime.global().setProperty(runtime, "__QuickCryptoProxy",
                                  std::move(object));
-    // Adds the PropNameIDCache object to the Runtime. If the Runtime gets destroyed, the Object gets destroyed and the cache gets invalidated.
-    auto propNameIdCache = std::make_shared<InvalidateCacheOnDestroy>(runtime);
+    // Adds the MGLPropNameIDCache object to the Runtime. If the Runtime gets destroyed, the Object gets destroyed and the cache gets invalidated.
+    auto propNameIdCache = std::make_shared<MGLInvalidateCacheOnDestroy>(runtime);
     runtime.global().setProperty(
       runtime,
       "rnqcArrayBufferPropNameIdCache",

--- a/packages/react-native-quick-crypto/cpp/JSIUtils/MGLTypedArray.cpp
+++ b/packages/react-native-quick-crypto/cpp/JSIUtils/MGLTypedArray.cpp
@@ -39,7 +39,7 @@ enum class Prop {
   Float64Array,       // "Float64Array"
 };
 
-class PropNameIDCache {
+class MGLPropNameIDCache {
  public:
   const jsi::PropNameID &get(jsi::Runtime &runtime, Prop prop) {
     auto key = reinterpret_cast<uintptr_t>(&runtime);
@@ -65,16 +65,16 @@ class PropNameIDCache {
   jsi::PropNameID createProp(jsi::Runtime &runtime, Prop prop);
 };
 
-PropNameIDCache propNameIDCache;
+MGLPropNameIDCache propNameIDCache;
 
-InvalidateCacheOnDestroy::InvalidateCacheOnDestroy(jsi::Runtime &runtime) {
+MGLInvalidateCacheOnDestroy::MGLInvalidateCacheOnDestroy(jsi::Runtime &runtime) {
   key = reinterpret_cast<uintptr_t>(&runtime);
 }
-InvalidateCacheOnDestroy::~InvalidateCacheOnDestroy() {
+MGLInvalidateCacheOnDestroy::~MGLInvalidateCacheOnDestroy() {
   propNameIDCache.invalidate(key);
 }
 
-MGLTypedArrayKind getTypedArrayKindForName(const std::string &name);
+MGLTypedArrayKind MGLgetTypedArrayKindForName(const std::string &name);
 
 MGLTypedArrayBase::MGLTypedArrayBase(jsi::Runtime &runtime, size_t size,
                                      MGLTypedArrayKind kind)
@@ -101,7 +101,7 @@ MGLTypedArrayKind MGLTypedArrayBase::getKind(jsi::Runtime &runtime) const {
           .getProperty(runtime, propNameIDCache.get(runtime, Prop::Name))
           .asString(runtime)
           .utf8(runtime);
-  return getTypedArrayKindForName(constructorName);
+  return MGLgetTypedArrayKindForName(constructorName);
 }
 
 size_t MGLTypedArrayBase::size(jsi::Runtime &runtime) const {
@@ -147,7 +147,7 @@ jsi::ArrayBuffer MGLTypedArrayBase::getBuffer(jsi::Runtime &runtime) const {
   }
 }
 
-bool isTypedArray(jsi::Runtime &runtime, const jsi::Object &jsObj) {
+bool MGLisTypedArray(jsi::Runtime &runtime, const jsi::Object &jsObj) {
   auto jsVal =
       runtime.global()
           .getProperty(runtime, propNameIDCache.get(runtime, Prop::ArrayBuffer))
@@ -164,7 +164,7 @@ bool isTypedArray(jsi::Runtime &runtime, const jsi::Object &jsObj) {
   }
 }
 
-MGLTypedArrayBase getTypedArray(jsi::Runtime &runtime,
+MGLTypedArrayBase MGLgetTypedArray(jsi::Runtime &runtime,
                                 const jsi::Object &jsObj) {
   auto jsVal =
       runtime.global()
@@ -182,7 +182,7 @@ MGLTypedArrayBase getTypedArray(jsi::Runtime &runtime,
   }
 }
 
-std::vector<uint8_t> arrayBufferToVector(jsi::Runtime &runtime,
+std::vector<uint8_t> MGLarrayBufferToVector(jsi::Runtime &runtime,
                                          jsi::Object &jsObj) {
   if (!jsObj.isArrayBuffer(runtime)) {
     throw std::runtime_error("Object is not an ArrayBuffer");
@@ -197,7 +197,7 @@ std::vector<uint8_t> arrayBufferToVector(jsi::Runtime &runtime,
   return std::vector<uint8_t>(dataBlock, dataBlock + blockSize);
 }
 
-void arrayBufferUpdate(jsi::Runtime &runtime, jsi::ArrayBuffer &buffer,
+void MGLarrayBufferUpdate(jsi::Runtime &runtime, jsi::ArrayBuffer &buffer,
                        std::vector<uint8_t> data, size_t offset) {
   uint8_t *dataBlock = buffer.data(runtime);
   size_t blockSize = buffer.size(runtime);
@@ -257,7 +257,7 @@ uint8_t* MGLTypedArray<T>::data(jsi::Runtime &runtime) {
   return getBuffer(runtime).data(runtime) + byteOffset(runtime);
 }
 
-const jsi::PropNameID &PropNameIDCache::getConstructorNameProp(
+const jsi::PropNameID &MGLPropNameIDCache::getConstructorNameProp(
     jsi::Runtime &runtime, MGLTypedArrayKind kind) {
   switch (kind) {
     case MGLTypedArrayKind::Int8Array:
@@ -281,7 +281,7 @@ const jsi::PropNameID &PropNameIDCache::getConstructorNameProp(
   }
 }
 
-jsi::PropNameID PropNameIDCache::createProp(jsi::Runtime &runtime, Prop prop) {
+jsi::PropNameID MGLPropNameIDCache::createProp(jsi::Runtime &runtime, Prop prop) {
   auto create = [&](const std::string &propName) {
     return jsi::PropNameID::forUtf8(runtime, propName);
   };
@@ -337,7 +337,7 @@ std::unordered_map<std::string, MGLTypedArrayKind> nameToKindMap = {
     {"Float64Array", MGLTypedArrayKind::Float64Array},
 };
 
-MGLTypedArrayKind getTypedArrayKindForName(const std::string &name) {
+MGLTypedArrayKind MGLgetTypedArrayKindForName(const std::string &name) {
   return nameToKindMap.at(name);
 }
 

--- a/packages/react-native-quick-crypto/cpp/JSIUtils/MGLTypedArray.h
+++ b/packages/react-native-quick-crypto/cpp/JSIUtils/MGLTypedArray.h
@@ -69,13 +69,13 @@ struct typedArrayTypeMap<MGLTypedArrayKind::Float64Array> {
   typedef double type;
 };
 
-// Instance of this class will invalidate PropNameIDCache when destructor is called.
+// Instance of this class will invalidate MGLPropNameIDCache when destructor is called.
 // Attach this object to global in specific jsi::Runtime to make sure lifecycle of
 // the cache object is connected to the lifecycle of the js runtime
-class InvalidateCacheOnDestroy : public jsi::HostObject {
+class MGLInvalidateCacheOnDestroy : public jsi::HostObject {
  public:
-  explicit InvalidateCacheOnDestroy(jsi::Runtime &runtime);
-  virtual ~InvalidateCacheOnDestroy();
+  explicit MGLInvalidateCacheOnDestroy(jsi::Runtime &runtime);
+  virtual ~MGLInvalidateCacheOnDestroy();
   virtual jsi::Value get(jsi::Runtime &, const jsi::PropNameID &name) {
     return jsi::Value::null();
   }
@@ -123,13 +123,13 @@ class MGLTypedArrayBase : public jsi::Object {
   friend class MGLTypedArray;
 };
 
-bool isTypedArray(jsi::Runtime &runtime, const jsi::Object &jsObj);
-MGLTypedArrayBase getTypedArray(jsi::Runtime &runtime,
+bool MGLisTypedArray(jsi::Runtime &runtime, const jsi::Object &jsObj);
+MGLTypedArrayBase MGLgetTypedArray(jsi::Runtime &runtime,
                                 const jsi::Object &jsObj);
 
-std::vector<uint8_t> arrayBufferToVector(jsi::Runtime &runtime,
+std::vector<uint8_t> MGLarrayBufferToVector(jsi::Runtime &runtime,
                                          jsi::Object &jsObj);
-void arrayBufferUpdate(jsi::Runtime &runtime, jsi::ArrayBuffer &buffer,
+void MGLarrayBufferUpdate(jsi::Runtime &runtime, jsi::ArrayBuffer &buffer,
                        std::vector<uint8_t> data, size_t offset);
 
 template <MGLTypedArrayKind T>

--- a/packages/react-native-quick-crypto/ios/QuickCryptoModule.mm
+++ b/packages/react-native-quick-crypto/ios/QuickCryptoModule.mm
@@ -41,9 +41,9 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(install) {
   auto object = jsi::Object::createFromHostObject(runtime, hostObject);
   runtime.global().setProperty(runtime, "__QuickCryptoProxy", std::move(object));
 
-  // Adds the PropNameIDCache object to the Runtime. If the Runtime gets
+  // Adds the MGLPropNameIDCache object to the Runtime. If the Runtime gets
   // destroyed, the Object gets destroyed and the cache gets invalidated.
-  auto propNameIdCache = std::make_shared<InvalidateCacheOnDestroy>(runtime);
+  auto propNameIdCache = std::make_shared<MGLInvalidateCacheOnDestroy>(runtime);
   runtime.global().setProperty(
     runtime,
     "rnqcArrayBufferPropNameIdCache",


### PR DESCRIPTION
 **PR Summary by Typo**
------------

**Overview:**
This PR fixes duplicate symbol errors during build by adding the `MGL` prefix to several classes and functions within the `react-native-quick-crypto` package.  This specifically addresses conflicts arising from the `PropNameIDCache`, `InvalidateCacheOnDestroy`, and related functions.

**Key Changes:**
- Renamed `PropNameIDCache` to `MGLPropNameIDCache`.
- Renamed `InvalidateCacheOnDestroy` to `MGLInvalidateCacheOnDestroy`.
- Prefixed related functions like `isTypedArray`, `getTypedArray`, `arrayBufferToVector`, and `arrayBufferUpdate` with `MGL`.
- Updated references to these renamed classes and functions throughout the affected files.

**Recommendations:**
Ready for deployment. This fix effectively addresses the symbol conflict issue with minimal changes, improving the build stability of the `react-native-quick-crypto` package.

### 🗂️ Work Breakdown

| Category | Lines Changed |
|---|---|
| Rework | 50 (100%) |
| Total Changes | 50 |
 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>