### PR TITLE
🐛 fix: release error

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,5 +17,5 @@ bun install
 
 ```bash
 npm login
-bun release
+bun release $RELEASE_VERSION # e.g.: 0.7.17-cbx.0
 ```

--- a/README.md
+++ b/README.md
@@ -19,3 +19,34 @@ bun install
 npm login
 bun release $RELEASE_VERSION # e.g.: 0.7.17-cbx.0
 ```
+
+Example log for publishing:
+
+```bash
+❯ bun release 0.7.17-cbx.6
+$ ./scripts/release.sh 0.7.17-cbx.6
+Starting the release process...
+Provided options: 0.7.17-cbx.6
+Publishing 'react-native-quick-crypto' to NPM
+$ release-it 0.7.17-cbx.6
+
+🚀 Let's release @coolwallet-app/react-native-quick-crypto (0.7.17-cbx.5...0.7.17-cbx.6)
+
+
+Empty changelog
+
+✔ bun tsc && bun lint && bun format && bun prepare
+? Publish @coolwallet-app/react-native-quick-crypto@cbx to npm? Yes
+? Please enter OTP for npm: 513493
+🔗 https://registry.npmjs.org/package/@coolwallet-app/react-native-quick-crypto
+🏁 Done (in 225s.)
+Successfully released QuickCrypto!
+```
+
+# Develop flow
+
+- Create pull request into cbx branch
+- After the PR merged, publish to npm on cbx branch
+- Create git tag and github release
+  - Example git tag: v0.7.17-cbx.6
+  - Using auto-generate notes from GitHub GUI

--- a/README.md
+++ b/README.md
@@ -48,5 +48,5 @@ Successfully released QuickCrypto!
 - Create pull request into cbx branch
 - After the PR merged, publish to npm on cbx branch
 - Create git tag and github release
-  - Example git tag: v0.7.17-cbx.6
+  - Example git tag: `v0.7.17-cbx.6`
   - Using auto-generate notes from GitHub GUI

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.7.17",
+  "version": "0.7.17-cbx.4",
   "scripts": {
     "clean": "bun --filter='*' clean",
     "deepclean": "bun --filter='*' deepclean && del-cli node_modules",

--- a/package.json
+++ b/package.json
@@ -32,12 +32,6 @@
       "tagName": "v${version}",
       "requireCleanWorkingDir": false
     },
-    "github": {
-      "release": true
-    },
-    "hooks": {
-      "before:release": "bun bundle-install && bun pods && git add packages/example/ios/Podfile.lock"
-    },
     "plugins": {
       "@release-it/conventional-changelog": {
         "preset": {

--- a/packages/react-native-quick-crypto/package.json
+++ b/packages/react-native-quick-crypto/package.json
@@ -107,19 +107,6 @@
     },
     "hooks": {
       "after:bump": "bun tsc && bun lint && bun format && bun prepare"
-    },
-    "plugins": {
-      "@release-it/bumper": {
-        "out": [
-          {
-            "file": "../../packages/example/package.json",
-            "path": [
-              "version",
-              "dependencies.react-native-quick-crypto"
-            ]
-          }
-        ]
-      }
     }
   },
   "react-native-builder-bob": {

--- a/packages/react-native-quick-crypto/package.json
+++ b/packages/react-native-quick-crypto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coolwallet-app/react-native-quick-crypto",
-  "version": "0.7.17-cbx.5",
+  "version": "0.7.17-cbx.6",
   "description": "A fast implementation of Node's `crypto` module written in C/C++ JSI",
   "packageManager": "bun@1.1.26",
   "main": "lib/commonjs/index",

--- a/packages/react-native-quick-crypto/package.json
+++ b/packages/react-native-quick-crypto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coolwallet-app/react-native-quick-crypto",
-  "version": "0.7.17",
+  "version": "0.7.17-cbx.4",
   "description": "A fast implementation of Node's `crypto` module written in C/C++ JSI",
   "packageManager": "bun@1.1.26",
   "main": "lib/commonjs/index",

--- a/packages/react-native-quick-crypto/package.json
+++ b/packages/react-native-quick-crypto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coolwallet-app/react-native-quick-crypto",
-  "version": "0.7.17-cbx.4",
+  "version": "0.7.17-cbx.5",
   "description": "A fast implementation of Node's `crypto` module written in C/C++ JSI",
   "packageManager": "bun@1.1.26",
   "main": "lib/commonjs/index",

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -14,4 +14,4 @@ bun release $@
 # cd ../..
 # bun run release-it $@
 
-echo "\nSuccessfully released QuickCrypto!"
+echo "Successfully released QuickCrypto!"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -10,8 +10,8 @@ cp README.md packages/react-native-quick-crypto/README.md
 cd packages/react-native-quick-crypto
 bun release $@
 
-echo "Creating a Git bump commit and GitHub release"
-cd ../..
-bun run release-it $@
+# echo "Creating a Git bump commit and GitHub release"
+# cd ../..
+# bun run release-it $@
 
 echo "\nSuccessfully released QuickCrypto!"


### PR DESCRIPTION
本地端測試 `bun release 0.7.17-cbx.6` 成功
 
 
 
 **PR Summary by Typo**
------------

**Overview**
This PR addresses and fixes errors in the release process by updating the release script, streamlining `release-it` configurations, and clarifying the release instructions in the `README.md`. The goal is to ensure a smoother and more reliable package publishing workflow.

**Key Changes**
- Simplified the `release.sh` script to only publish the package, removing the redundant second `release-it` command for Git operations.
- Updated the `README.md` with explicit instructions for using `bun release $RELEASE_VERSION` and a detailed example log for publishing.
- Removed `github` and `hooks.before:release` configurations from the root `package.json` and the `@release-it/bumper` plugin from `packages/react-native-quick-crypto/package.json` to streamline the release-it setup.
- Updated package versions in `package.json` and `packages/react-native-quick-crypto/package.json` to reflect `cbx` pre-release versions.

**Recommendations**
ready for deployment. This PR fixes an operational issue in the release process without affecting runtime code and improves documentation for developers.

### 🗂️ Work Breakdown

| Category    | Lines Changed |
|-------------|---------------|
| New Work    | 31 (54.4%)    |
| Churn       | 19 (33.3%)    |
| Rework      | 7 (12.3%)     |
| Total Changes | 57            | 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>